### PR TITLE
Resolve Block staking error

### DIFF
--- a/src/wallet/staking.cpp
+++ b/src/wallet/staking.cpp
@@ -478,10 +478,10 @@ bool CreateCoinStake(CWallet& wallet, unsigned int nBits, int64_t nSearchInterva
 
     // Sign
     int nIn = 0;
-    SignatureData empty;
 
     if (wallet.IsLegacy()) {
         for (const auto &pcoin : vwtxPrev) {
+            SignatureData empty;
             if (!SignSignature(*wallet.GetLegacyScriptPubKeyMan(), *pcoin, txNew, nIn++, SIGHASH_ALL, empty))
                 return error("CreateCoinStake : failed to sign coinstake");
         }


### PR DESCRIPTION
Removed SignatureData from SignSignature function

By passing SignatureData at the createcoinstake, I believe the values were getting recycled causing subsequent inputs to be signed with the same data (hence the repetition of the scriptsig value in the 2nd and subsequent inputs

For viability, I have not adjusted any other code,
but doing a quick browse, should be able to switch all other function calls to eliminate the need to include SignatureData in  SignSignature function.